### PR TITLE
Add the URL variable back in

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ title: Emma Sax
 author: Emma Sax
 description: Emma Sax's personal website and blog. Includes information about my social media profiles, resumé, and hobbies.
 
-url: https://emmasax4.com
+url: https://emmasax4.com # when running the Jekyll server locally, this becomes the local URL
 domain: emmasax4.com
 github_repo: https://github.com/emmasax4/emmasax4.com
 

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ title: Emma Sax
 author: Emma Sax
 description: Emma Sax's personal website and blog. Includes information about my social media profiles, resumé, and hobbies.
 
-url: https://emmasax4.com # when running the Jekyll server locally, this becomes the local URL
+url: https://emmasax4.com # when running the Jekyll server locally, this becomes the local URL; removing this will break the nav bar URLs
 domain: emmasax4.com
 github_repo: https://github.com/emmasax4/emmasax4.com
 

--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,7 @@ title: Emma Sax
 author: Emma Sax
 description: Emma Sax's personal website and blog. Includes information about my social media profiles, resumé, and hobbies.
 
+url: https://emmasax4.com
 domain: emmasax4.com
 github_repo: https://github.com/emmasax4/emmasax4.com
 


### PR DESCRIPTION
## Changes

> A list of the changes that your pull request will make:
>
> * Adding a page "..."
> * Refactoring "..."

As it can be seen [here](https://github.com/emmasax4/emmasax4.com/commit/b780da54259c631ae1b4e456e134cd83377fbb11), apparently the `site.url` variable is only automatically set when running the server locally. When running via GitHub Actions, it needs to be set in the `_config.yml` file along with the rest of the variables.

I added a comment to help remind me later why I need that.

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue #1
> * Issue #2
> * Pull Request #1
> * Pull Request #2

* https://github.com/emmasax4/emmasax4.com/pull/307

## Additional Context

> Add any other context about the problem here.

## PR Scheduler

> If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
>
> ```
> # example (May 18, 2020 at 17:58 UTC):
> @prscheduler 2020-05-18 17:58
>
> @prscheduler YYYY-MM-DD HH:MM
> ```
