### PR TITLE
Split steps of each job into sections

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -4,46 +4,47 @@ on:
     - cron: "30 5 * * 1" # On Mondays: 05:30 UTC => 00:30 CDT / 23:30 CST
 
 jobs:
-  test:
+  build-test:
     runs-on: ubuntu-latest
     steps:
-    - name: Check Out Code
+    - name: 'Setup: Check Out Code'
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
 
-    - name: Define Run Variables
+    - name: 'Setup: Define Run Variables'
       run: bash scripts/define_run_variables.sh cron ${{ github.repository }} ${{ github.ref }} ${{ github.run_id }}
 
-    - name: Switch to Current Branch
+    - name: 'Setup: Switch to Current Branch'
       run: git checkout ${{ env.BRANCH }}
 
-    - name: Configure System
+    - name: 'Setup: Configure System'
       run: sudo gem update --system 3.0.8 && sudo gem install bundler -v $(cat Gemfile.lock | tail -1 | tr -d " ")
 
-    - name: Configure Gem Cache
+    - name: 'Setup: Configure Gem Cache'
       uses: actions/cache@v2
       with:
         path: vendor/bundle
         key: bundler-cache-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: bundler-cache-
 
-    - name: Install Gems
+    - name: 'Build: Install Gems'
       run: bundle config set path "vendor/bundle" && bundle install
 
-    - name: Jekyll Build
+    - name: 'Build: Jekyll Build'
       run: JEKYLL_ENV=production bundle exec jekyll build --destination _site
 
-    - name: HTML Proofer
-      run: bash scripts/html_proofer.sh || echo ""
+    - name: 'Test: HTML Proofer'
+      run: bash scripts/html_proofer.sh
+      continue-on-error: true
 
-    - name: Rubocop
+    - name: 'Test: Rubocop'
       run: bundle exec rubocop
 
-    - name: Markdown Linter
+    - name: 'Test: Markdown Linter'
       run: bash scripts/markdown_linter.sh
 
-    - name: Notify Slack on Success
+    - name: 'Notifications: Notify Slack on Success'
       if: success()
       uses: emmasax4/slack-notifier-action@main
       with:
@@ -58,7 +59,7 @@ jobs:
         author_icon: https://i.imgur.com/kUxzV44s.png
         text: Build <${{ env.BUILD_URL }}|${{ github.run_id }}> on branch `${{ env.BRANCH }}` *passed*.
 
-    - name: Notify Slack on Failure
+    - name: 'Notifications: Notify Slack on Failure'
       if: failure()
       uses: emmasax4/slack-notifier-action@main
       with:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -38,10 +38,6 @@ jobs:
       run: bash scripts/html_proofer.sh
       continue-on-error: true
 
-    - name: DELETE ME LATER
-      run: exit 125
-      continue-on-error: true
-
     - name: 'Test: Rubocop'
       run: bundle exec rubocop
 

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -36,6 +36,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    needs: build
     steps:
     - name: HTML Proofer
       run: bash scripts/html_proofer.sh || echo ""
@@ -48,6 +49,7 @@ jobs:
 
   notify-slack:
     runs-on: ubuntu-latest
+    needs: test
     steps:
     - name: Notify Slack on Success
       if: success()

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -38,6 +38,10 @@ jobs:
       run: bash scripts/html_proofer.sh
       continue-on-error: true
 
+    - name: DELETE ME LATER
+      run: exit 125
+      continue-on-error: true
+
     - name: 'Test: Rubocop'
       run: bundle exec rubocop
 

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -35,7 +35,8 @@ jobs:
       run: JEKYLL_ENV=production bundle exec jekyll build --destination _site
 
     - name: 'Test: HTML Proofer'
-      run: bash scripts/html_proofer.sh || echo ""
+      run: bash scripts/html_proofer.sh
+      continue-on-error: true
 
     - name: 'Test: Rubocop'
       run: bundle exec rubocop

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -4,7 +4,7 @@ on:
     branches: [ main ]
 
 jobs:
-  test:
+  build:
     runs-on: ubuntu-latest
     steps:
     - name: Check Out Code
@@ -34,6 +34,7 @@ jobs:
     - name: Jekyll Build
       run: JEKYLL_ENV=production bundle exec jekyll build --destination _site
 
+  test:
     - name: HTML Proofer
       run: bash scripts/html_proofer.sh || echo ""
 
@@ -43,6 +44,7 @@ jobs:
     - name: Markdown Linter
       run: bash scripts/markdown_linter.sh
 
+  notify-slack:
     - name: Notify Slack on Success
       if: success()
       uses: emmasax4/slack-notifier-action@main

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -35,6 +35,8 @@ jobs:
       run: JEKYLL_ENV=production bundle exec jekyll build --destination _site
 
   test:
+    runs-on: ubuntu-latest
+    steps:
     - name: HTML Proofer
       run: bash scripts/html_proofer.sh || echo ""
 
@@ -45,6 +47,8 @@ jobs:
       run: bash scripts/markdown_linter.sh
 
   notify-slack:
+    runs-on: ubuntu-latest
+    steps:
     - name: Notify Slack on Success
       if: success()
       uses: emmasax4/slack-notifier-action@main

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -4,54 +4,46 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  build-test:
     runs-on: ubuntu-latest
     steps:
-    - name: Check Out Code
+    - name: 'Setup: Check Out Code'
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
 
-    - name: Define Run Variables
+    - name: 'Setup: Define Run Variables'
       run: bash scripts/define_run_variables.sh develop ${{ github.repository }} ${{ github.ref }} ${{ github.run_id }} ${{ github.head_ref }}
 
-    - name: Switch to Current Branch
+    - name: 'Setup: Switch to Current Branch'
       run: git checkout ${{ env.BRANCH }}
 
-    - name: Configure System
+    - name: 'Setup: Configure System'
       run: sudo gem update --system 3.0.8 && sudo gem install bundler -v $(cat Gemfile.lock | tail -1 | tr -d " ")
 
-    - name: Configure Gem Cache
+    - name: 'Setup: Configure Gem Cache'
       uses: actions/cache@v2
       with:
         path: vendor/bundle
         key: bundler-cache-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: bundler-cache-
 
-    - name: Install Gems
+    - name: 'Build: Install Gems'
       run: bundle config set path "vendor/bundle" && bundle install
 
-    - name: Jekyll Build
+    - name: 'Build: Jekyll Build'
       run: JEKYLL_ENV=production bundle exec jekyll build --destination _site
 
-  test:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-    - name: HTML Proofer
+    - name: 'Test: HTML Proofer'
       run: bash scripts/html_proofer.sh || echo ""
 
-    - name: Rubocop
+    - name: 'Test: Rubocop'
       run: bundle exec rubocop
 
-    - name: Markdown Linter
+    - name: 'Test: Markdown Linter'
       run: bash scripts/markdown_linter.sh
 
-  notify-slack:
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-    - name: Notify Slack on Success
+    - name: 'Notifications: Notify Slack on Success'
       if: success()
       uses: emmasax4/slack-notifier-action@main
       with:
@@ -68,7 +60,7 @@ jobs:
           Build <${{ env.BUILD_URL }}|${{ github.run_id }}> on branch `${{ env.BRANCH }}`
           in PR <${{ env.PULL_URL }}|#${{ env.PULL_ID }}> *passed*.
 
-    - name: Notify Slack on Failure
+    - name: 'Notifications: Notify Slack on Failure'
       if: failure()
       uses: emmasax4/slack-notifier-action@main
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,46 +4,47 @@ on:
     branches: [ main ]
 
 jobs:
-  test-and-deploy:
+  build-test-deploy:
     runs-on: ubuntu-latest
     steps:
-    - name: Check Out Code
+    - name: 'Setup: Check Out Code'
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
 
-    - name: Define Run Variables
+    - name: 'Setup: Define Run Variables'
       run: bash scripts/define_run_variables.sh release ${{ github.repository }} ${{ github.ref }} ${{ github.run_id }} ${{ github.actor }}
 
-    - name: Switch to Current Branch
+    - name: 'Setup: Switch to Current Branch'
       run: git checkout ${{ env.BRANCH }}
 
-    - name: Configure System
+    - name: 'Setup: Configure System'
       run: sudo gem update --system 3.0.8 && sudo gem install bundler -v $(cat Gemfile.lock | tail -1 | tr -d " ")
 
-    - name: Configure Gem Cache
+    - name: 'Setup: Configure Gem Cache'
       uses: actions/cache@v2
       with:
         path: vendor/bundle
         key: bundler-cache-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: bundler-cache-
 
-    - name: Install Gems
+    - name: 'Build: Install Gems'
       run: bundle config set path "vendor/bundle" && bundle install
 
-    - name: Jekyll Build
+    - name: 'Build: Jekyll Build'
       run: JEKYLL_ENV=production bundle exec jekyll build --destination _site
 
-    - name: HTML Proofer
-      run: bash scripts/html_proofer.sh || echo ""
+    - name: 'Test: HTML Proofer'
+      run: bash scripts/html_proofer.sh
+      continue-on-error: true
 
-    - name: Rubocop
+    - name: 'Test: Rubocop'
       run: bundle exec rubocop
 
-    - name: Markdown Linter
+    - name: 'Test: Markdown Linter'
       run: bash scripts/markdown_linter.sh
 
-    - name: GitHub Pages Deploy
+    - name: 'Deploy: GitHub Pages Deploy'
       uses: emmasax4/github-pages-deploy-action@main
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -55,10 +56,10 @@ jobs:
         git_config_email: 41898282+github-actions[bot]@users.noreply.github.com
         git_config_name: github-actions[bot]
 
-    - name: Set Deploy Status Message
+    - name: 'Notifications: Set Deploy Status Message'
       run: bash scripts/set_deploy_status_message.sh ${{ env.DEPLOYMENT_STATUS }}
 
-    - name: Notify Slack on Success
+    - name: 'Notifications: Notify Slack on Success'
       if: success()
       uses: emmasax4/slack-notifier-action@main
       with:
@@ -75,7 +76,7 @@ jobs:
           Build <${{ env.BUILD_URL }}|${{ github.run_id }}> on branch `${{ env.BRANCH }}`
           *passed*. ${{ env.DEPLOY_MESSAGE }}.
 
-    - name: Notify Slack on Failure
+    - name: 'Notifications: Notify Slack on Failure'
       if: failure()
       uses: emmasax4/slack-notifier-action@main
       with:


### PR DESCRIPTION
## Changes

My ideal state would be to share the information from job to job. So one workflow runs different jobs to build, test, deploy (if deploy is applicable), and notify Slack. However, I guess GitHub Actions runs each job on a different runner environment, so environment variables and files can't persist how I'd like them to. Maybe someday GitHub will make a way for that information to be passed along from job to job.

So, what I'm opting to do instead is to break down each workflow into separate categories (denoted by the naming of each step). They are broken down into:
* Setup
* Build
* Test
* Deploy (optional)
* Notifications

Each step in the job/workflow belongs to one of these categories (except for the few steps at the beginning and end that are automatically generated).

This is still not the ideal state, and if GitHub Actions ever allows env variables and local code to persist from job to job, I'd love to take advantage of that.

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue #1
> * Issue #2
> * Pull Request #1
> * Pull Request #2

## Additional Context

> Add any other context about the problem here.

## PR Scheduler

> If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
>
> ```
> # example (May 18, 2020 at 17:58 UTC):
> @prscheduler 2020-05-18 17:58
>
> @prscheduler YYYY-MM-DD HH:MM
> ```
