### PR TITLE
Remove extra workflow spaces

### DIFF
--- a/scripts/set_workflow_environment_variables.sh
+++ b/scripts/set_workflow_environment_variables.sh
@@ -8,6 +8,14 @@ gh_actor=$4
 gh_ref=$5
 head_ref=$6
 
+echo "event:$event_name"
+echo "repository:$repository"
+echo "run_id:$run_id"
+echo "gh_actor:$gh_actor"
+echo "gh_ref:$gh_ref"
+echo "head_ref:$head_ref"
+
+
 build_url="https://github.com/$repository/actions/runs/$run_id"
 
 if [[ $gh_ref == 'refs/pull'* ]]; then # this is a pull request

--- a/scripts/set_workflow_environment_variables.sh
+++ b/scripts/set_workflow_environment_variables.sh
@@ -2,20 +2,12 @@
 
 # These variables must be provided to this script in the same order as listed here
 args="$*"
-event_name=$(echo $args | cut -d " " -f $1)
-repository=$(echo $args | cut -d " " -f $2)
-run_id=$(echo $args | cut -d " " -f $3)
-gh_actor=$(echo $args | cut -d " " -f $4)
-gh_ref=$(echo $args | cut -d " " -f $5)
-head_ref=$(echo $args | cut -d " " -f $6)
-
-echo "event:$event_name"
-echo "repository:$repository"
-echo "run_id:$run_id"
-echo "gh_actor:$gh_actor"
-echo "gh_ref:$gh_ref"
-echo "head_ref:$head_ref"
-
+event_name=$(echo $args | cut -d " " -f 1)
+repository=$(echo $args | cut -d " " -f 2)
+run_id=$(echo $args | cut -d " " -f 3)
+gh_actor=$(echo $args | cut -d " " -f 4)
+gh_ref=$(echo $args | cut -d " " -f 5)
+head_ref=$(echo $args | cut -d " " -f 6)
 
 build_url="https://github.com/$repository/actions/runs/$run_id"
 

--- a/scripts/set_workflow_environment_variables.sh
+++ b/scripts/set_workflow_environment_variables.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
 # These variables must be provided to this script in the same order as listed here
-event_name=$1
-repository=$2
-run_id=$3
-gh_actor=$4
-gh_ref=$5
-head_ref=$6
+args="$*"
+event_name=$(echo $args | cut -d " " -f $1)
+repository=$(echo $args | cut -d " " -f $2)
+run_id=$(echo $args | cut -d " " -f $3)
+gh_actor=$(echo $args | cut -d " " -f $4)
+gh_ref=$(echo $args | cut -d " " -f $5)
+head_ref=$(echo $args | cut -d " " -f $6)
 
 echo "event:$event_name"
 echo "repository:$repository"


### PR DESCRIPTION
## Changes

Apparently I was accidentally passing some whitespaces into the `set_workflow_environment_variables` script. So now strip all of those whitespaces off of all of the incoming variables.

Also, because it's a good idea, use this opportunity to also test PR Scheduler with the new workflows.

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue #1
> * Issue #2
> * Pull Request #1
> * Pull Request #2

## Additional Context

> Add any other context about the problem here.

## PR Scheduler

> If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
>
> ```
> # example (May 18, 2020 at 17:58 UTC):
> @prscheduler 2020-05-18 17:58
>
> @prscheduler YYYY-MM-DD HH:MM
> ```
