### PR TITLE
Name the 404 page

### DIFF
--- a/pages/404.md
+++ b/pages/404.md
@@ -1,5 +1,6 @@
 ---
 layout: default
+title: 404
 permalink: /404
 ---
 


### PR DESCRIPTION
## Changes

Actually name the 404 page `"404"`. This means that on the top bar, the page will actually say 404. This is what it currently states:
![image](https://user-images.githubusercontent.com/7562793/102692193-6ef11700-41d7-11eb-8aa1-fb2144d3be31.png)

But now with this change, the tab looks like this:
![image](https://user-images.githubusercontent.com/7562793/102692224-99db6b00-41d7-11eb-8cec-8fa1997872f3.png)

The actual 404 page is not changing... I rather like the cute 404 stop sign 😄 .

---

**PR Scheduler**

> If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
>
> ```
> # example (May 18, 2020 at 17:58 UTC):
> @prscheduler 2020-05-18 17:58
>
> @prscheduler YYYY-MM-DD HH:MM
> ```
