### PR TITLE
Test different fetch-depth options

### DIFF
--- a/.github/scripts/set_environment_variables.sh
+++ b/.github/scripts/set_environment_variables.sh
@@ -9,6 +9,9 @@ author=$(echo $args | cut -d " " -f 4)
 ref=$(echo $args | cut -d " " -f 5)
 head_ref=$(echo $args | cut -d " " -f 6)
 
+echo "Head Ref: $head_ref"
+echo "Ref: $ref"
+
 if [[ $ref == "refs/pull"* ]]; then # this is a pull request
   pull_id=$(echo $ref | sed -E "s|refs/pull/||" | sed -E "s|/merge||")
   build_message_addition=" in PR <https://github.com/$repository/pull/$pull_id|#$pull_id>"

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -12,11 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check Out Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v1
       with:
-        ref: ${{ github.HEAD_REF }}
+        ref: ${{ github.REF }}
+
+    - name: Check Out Deployed Code
+      uses: actions/checkout@v1
+      with:
         ref: gh-pages-test
-        persist-credentials: false
 
     - name: Set Environment Variables
       run: bash .github/scripts/set_environment_variables.sh \

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -15,6 +15,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         ref: ${{ github.HEAD_REF }}
+        persist-credentials: false
 
     - name: Set Environment Variables
       run: bash .github/scripts/set_environment_variables.sh \

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -20,6 +20,7 @@ jobs:
       uses: actions/checkout@v1
       with:
         ref: gh-pages-test
+        clean: false
 
     - name: Set Environment Variables
       run: bash .github/scripts/set_environment_variables.sh \

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
     - name: Check Out Code
       uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
 
     - name: Set Environment Variables
       run: bash .github/scripts/set_environment_variables.sh \

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -13,14 +13,6 @@ jobs:
     steps:
     - name: Check Out Code
       uses: actions/checkout@v1
-      with:
-        ref: ${{ github.REF }}
-
-    - name: Check Out Deployed Code
-      uses: actions/checkout@v1
-      with:
-        ref: gh-pages-test
-        clean: false
 
     - name: Set Environment Variables
       run: bash .github/scripts/set_environment_variables.sh \

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
     - name: Check Out Code
       uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
 
     - name: Set Environment Variables
       run: bash .github/scripts/set_environment_variables.sh \

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -43,6 +43,11 @@ jobs:
     - name: Markdown Linter
       run: bash .github/scripts/markdown_linter.sh
 
+    - name: Check Out Deployed Code
+      uses: actions/checkout@v2
+      with:
+        ref: gh-pages-test
+
     # Only run this step for events that are push commits to the main branch
     - name: Deploy Site
       uses: emmasax4/github-pages-deploy-action@main

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -44,51 +44,13 @@ jobs:
 
     # Only run this step for events that are push commits to the main branch
     - name: Deploy Site
-      if: github.EVENT_NAME == 'push' && github.REF == 'refs/heads/main'
       uses: emmasax4/github-pages-deploy-action@main
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: gh-pages
+        branch: gh-pages-test
         folder: _site
         clean: true
         silent: true
         commit_message: Deploy to ${{ github.REPOSITORY }}
         git_config_email: 41898282+github-actions[bot]@users.noreply.github.com
         git_config_name: github-actions[bot]
-
-    # Only run this step for events that are push commits to the main branch
-    - name: Set Final Deploy Message
-      if: github.EVENT_NAME == 'push' && github.REF == 'refs/heads/main'
-      run: bash .github/scripts/set_deploy_message.sh ${{ env.DEPLOYMENT_STATUS }}
-
-    # Only run this step if this build has been successful
-    - name: Notify Slack on Success
-      if: success()
-      uses: emmasax4/notify-slack-action@main
-      with:
-        slack_webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-        channel: general
-        icon_url: https://i.imgur.com/MH87j3l.png
-        username: GitHub Actions
-        color: "#23c22e"
-        title: ${{ github.REPOSITORY }}
-        title_link: https://github.com/${{ github.REPOSITORY }}
-        author_name: ${{ env.AUTHOR_NAME }}
-        author_icon: ${{ env.AUTHOR_ICON }}
-        text: ${{ env.BUILD_MESSAGE }} *passed*.${{ env.DEPLOY_MESSAGE }}
-
-    # Only run this step if this build has failed
-    - name: Notify Slack on Failure
-      if: failure()
-      uses: emmasax4/notify-slack-action@main
-      with:
-        slack_webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-        channel: general
-        icon_url: https://i.imgur.com/MH87j3l.png
-        username: GitHub Actions
-        color: "#bd2222"
-        title: ${{ github.REPOSITORY }}
-        title_link: https://github.com/${{ github.REPOSITORY }}
-        author_name: ${{ env.AUTHOR_NAME }}
-        author_icon: ${{ env.AUTHOR_ICON }}
-        text: ${{ env.BUILD_MESSAGE }} *failed*.${{ env.DEPLOY_MESSAGE }}

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -15,6 +15,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         ref: ${{ github.HEAD_REF }}
+        ref: gh-pages-test
         persist-credentials: false
 
     - name: Set Environment Variables
@@ -42,11 +43,6 @@ jobs:
 
     - name: Markdown Linter
       run: bash .github/scripts/markdown_linter.sh
-
-    - name: Check Out Deployed Code
-      uses: actions/checkout@v2
-      with:
-        ref: gh-pages-test
 
     # Only run this step for events that are push commits to the main branch
     - name: Deploy Site

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
     - name: Check Out Code
       uses: actions/checkout@v2
+      with:
+        ref: ${{ github.HEAD_REF }}
 
     - name: Set Environment Variables
       run: bash .github/scripts/set_environment_variables.sh \


### PR DESCRIPTION
## Changes

I wanted to experiment to see what would happen if I played with different `fetch-depth` options in the Checkout Code section of the Actions workflow. What I've deduced is two things: if I'm not going to use [checkout v2](https://github.com/actions/checkout/tree/v2.3.4) with `fetch-depth: 0`, then I need to use [checkout v1](https://github.com/actions/checkout/tree/v1.2.0), which will automatically use a fetch-depth of unlimited. Also, I need an unlimited `fetch-depth`, otherwise it'll deploy each page of the site as the `lastModified` date being the date of the workflow being run, when it's supposed to be the date the file was last modified on GitHub. So we need unlimited history for that correct `lastModified` date. [See the resulting commit when using a shorter `fetch-depth`](https://github.com/emmasax4/emmasax4.com/commit/a6972f3ab160ffe67a6f8563d183bdf54cfecbf1).

So essentially my options are to go back to using checkout v1, and then I don't need to specify the fetch-depth because the default is unlimited, or use checkout v2 and specify to use `fetch-depth: 0`. To be completely honest, I don't really have a preference which version of these two I use. Both aren't my ideal situation (ideally it just knows the `modifiedDate` on its own). So, given that neither option is perfect, I'll just keep it the way it is. This way I'll be more prepared to accept newer versions of the GitHub action when v3 comes out.

## Related Pull Requests and Issues

[Here's the original PR which switched to checkout v2 version](https://github.com/emmasax4/emmasax4.com/pull/283). I probably did all of my testing with that original PR (with the same results) and just forgot about my final decisions.

## Additional Context

Because of the reasons described above, I won't be merging this PR.

## PR Scheduler

> If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
>
> ```
> # example (May 18, 2020 at 17:58 UTC):
> @prscheduler 2020-05-18 17:58
>
> @prscheduler YYYY-MM-DD HH:MM
> ```
