### PR TITLE
Add URL back into _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,9 +11,9 @@ author_profiles:
   facebook: https://facebook.com/emmasax4
   email: emma.sax4@gmail.com
 
+url: https://emmasax4.com
 domain: emmasax4.com
 github_repo: emmasax4.com
-
 timezone: UTC
 jekyll-mentions: https://github.com
 


### PR DESCRIPTION
## Changes

I've actually decided to add the URL value back into the `_config.yml`. Although removing it didn't break anything, I want the URL to be present in the HTML header information more. [Here's](https://github.com/emmasax4/emmasax4.com/commit/b97bec30ce6a318f85e10e60e7e720abb496a77b) the commit of what it removed, and I'm unsatisfied with that.

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue #1
> * Issue #2
> * Pull Request #1
> * Pull Request #2

## Additional Context

> Add any other context about the problem here.

## PR Scheduler

> If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
>
> ```
> # example (May 18, 2020 at 17:58 UTC):
> @prscheduler 2020-05-18 17:58
>
> @prscheduler YYYY-MM-DD HH:MM
> ```
