### PR TITLE
Do not allow submissions if recaptcha is empty

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,6 +26,16 @@
     {% seo %}
   </head>
 
+  <script type="text/javascript">
+    function recaptchaCallback() {
+      $('#submitButton').removeAttr('disabled');
+    };
+
+    function recaptchaExpiredCallback() {
+      $('#submitButton').attr('disabled', true);
+    };
+  </script>
+
   <!-- Navigation bar -->
   {% include site_navigation.html %}
 

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -15,7 +15,7 @@ layout: default
     </div>
 
     <!-- Tagline and URL buttons -->
-    <div class="col-md text-center mt-5">
+    <div class="col-md text-center mt-2">
       {{ content | markdownify }}
 
       <div class="mt-5" style="padding-bottom:50px;">

--- a/pages/contact-me.md
+++ b/pages/contact-me.md
@@ -39,9 +39,11 @@ Please use this form to contact me directly. Do not send me any solicitation, re
   </div>
 
   <label>Please verify you're a person<span style="color: #d61b1b;">*</span></label>
-  <div class="g-recaptcha" data-sitekey="6Ld6_CcaAAAAAOXP4F6Ze2M5mbeqFRSEN9dlUecn" style="margin-top: -1rem; padding-bottom: .67rem;"></div>
+  <div class="g-recaptcha" data-callback="recaptchaCallback" data-expired-callback="recaptchaExpiredCallback"
+       data-sitekey="6Ld6_CcaAAAAAOXP4F6Ze2M5mbeqFRSEN9dlUecn" style="margin-top: -1rem; padding-bottom: .67rem;">
+  </div>
 
-  <button type="submit" class="btn btn-primary" style="width: 100%;">
+  <button type="submit" id="submitButton" disabled class="btn btn-primary" style="width: 100%;">
     Submit
   </button>
 </form>

--- a/pages/contact-me/thank-you.md
+++ b/pages/contact-me/thank-you.md
@@ -5,3 +5,7 @@ permalink: /contact-me/thank-you/
 ---
 
 Thank you for your message! I will respond back as soon as I am able.
+
+<div class="text-center container" style="padding-top: 1rem; padding-bottom: 1rem;">
+  <a href="/" class="btn btn-lg btn-outline-secondary">Back to Homepage</a>
+</div>


### PR DESCRIPTION
## Changes

@a-woodard found a bug where the Contact form will still send even if the reCaptcha is empty. So, this is an easy way for users to be held up... the Submit button will be disabled and greyed out if the reCaptcha is empty, and it'll become clickable if the reCaptcha is solved. If the reCaptcha expires then the button will become disabled again. There's probably still an API way around this that a hacker could find (or any programmer, or smart spammer), but it's good enough for typical humans on the client side.

This PR will also add a button to the Thank You page that redirects users back to the homepage, and raises the text on the index page a bit.

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue #1
> * Issue #2
> * Pull Request #1
> * Pull Request #2

## Additional Context

> Add any other context about the problem here.

## PR Scheduler

> If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
>
> ```
> # example (May 18, 2020 at 17:58 UTC):
> @prscheduler 2020-05-18 17:58
>
> @prscheduler YYYY-MM-DD HH:MM
> ```
