### PR TITLE
Use a separate form layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,16 +26,6 @@
     {% seo %}
   </head>
 
-  <script type="text/javascript">
-    function recaptchaCallback() {
-      $('#submitButton').removeAttr('disabled');
-    };
-
-    function recaptchaExpiredCallback() {
-      $('#submitButton').attr('disabled', true);
-    };
-  </script>
-
   <!-- Navigation bar -->
   {% include site_navigation.html %}
 

--- a/_layouts/form.html
+++ b/_layouts/form.html
@@ -1,0 +1,23 @@
+---
+layout: default
+---
+
+<!-- Title of page -->
+<div class="text-center">
+  <h1>{{ page.title }}</h1>
+</div>
+
+<script type="text/javascript">
+  function recaptchaCallback() {
+    $('#submitButton').removeAttr('disabled');
+  };
+
+  function recaptchaExpiredCallback() {
+    $('#submitButton').attr('disabled', true);
+  };
+</script>
+
+<!-- Actual page content -->
+<div class="page-body">
+  {{ content | markdownify }}
+</div>

--- a/pages/contact-me.md
+++ b/pages/contact-me.md
@@ -15,7 +15,7 @@ Please use this form to contact me directly. Do not send me any solicitation, re
 <iframe name="hidden_iframe"
         id="hidden_iframe"
         style="display: none;"
-        onload="if (submitted) { window.location='/contact-me/thank-you/'; }">
+        onload="if (submitted) { window.location.href = '/contact-me/thank-you/'; }">
 </iframe>
 
 <form action="https://docs.google.com/forms/d/e/1FAIpQLScEq299mdRxHN_dZ3tTdgp6KTYtcgUHHVbDr0DSX2-zDDCxuQ/formResponse"

--- a/pages/contact-me.md
+++ b/pages/contact-me.md
@@ -1,5 +1,5 @@
 ---
-layout: page
+layout: form
 title: Contact Me
 permalink: /contact-me/
 ---


### PR DESCRIPTION
## Changes

The contact form should have its own page, otherwise every single page will contain the two Javascript functions that _only_ the form pages need. See [this commit](https://github.com/emmasax4/emmasax4.com/commit/232d4ddf8379663e3a2e19b19e67231d529201a6) to see those two functions added to _every single page_. This PR should remove those.

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue #1
> * Issue #2
> * Pull Request #1
> * Pull Request #2

## Additional Context

> Add any other context about the problem here.

## PR Scheduler

> If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
>
> ```
> # example (May 18, 2020 at 17:58 UTC):
> @prscheduler 2020-05-18 17:58
>
> @prscheduler YYYY-MM-DD HH:MM
> ```
