### PR TITLE
Autocapitalize mobile keyboards

### DIFF
--- a/pages/contact-me.md
+++ b/pages/contact-me.md
@@ -25,7 +25,7 @@ Please use this form to contact me directly. Do not send me any solicitation, re
 >
   <div class="form-group">
     <label>Full Name<span style="color: #d61b1b;">*</span></label>
-    <input name="entry.989289036" type="text" class="form-control" id="name" style="text-transform: capitalize;" placeholder="John Doe" required>
+    <input name="entry.989289036" type="text" class="form-control" id="name" autocapitalize="words" placeholder="John Doe" required>
   </div>
 
   <div class="form-group">


### PR DESCRIPTION
## Changes

On mobile keyboards, when filling out the Full Name field of the contact page, auto-shift the first letter of each word. This PR will close #356.

And then also take away the `style="text-transform: capitalize;"` so that we're not manipulating peoples' text anymore. The text should appear as they're typing it, either with or without capitalized letters.

## Related Pull Requests and Issues

* https://github.com/emmasax4/emmasax4.com/issues/356

## Additional Context

> Add any other context about the problem here.

## PR Scheduler

> If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
>
> ```
> # example (May 18, 2020 at 17:58 UTC):
> @prscheduler 2020-05-18 17:58
>
> @prscheduler YYYY-MM-DD HH:MM
> ```
