### PR TITLE
Even more spam protection

### DIFF
--- a/_layouts/contact.html
+++ b/_layouts/contact.html
@@ -21,7 +21,7 @@ layout: default
 <div id="form" class="page-body">
   {{ content | markdownify }}
 
-  <form method="post" target="hidden_iframe" onsubmit="submitted=true;"
+  <form method="post" target="hidden_iframe" onsubmit="submitted = true;"
     action="https://docs.google.com/forms/d/e/1FAIpQLScEq299mdRxHN_dZ3tTdgp6KTYtcgUHHVbDr0DSX2-zDDCxuQ/formResponse"
   >
     <div class="form-group">
@@ -39,7 +39,12 @@ layout: default
       <textarea name="entry.1379036791" class="form-control" id="message" placeholder="Lorem ipsum dolor sit amet, consectetur adipiscing elit." rows="3" required></textarea>
     </div>
 
-    <label>Please verify you’re a person<span style="color: #d61b1b;">*</span></label>
+    <div class="form-group" style="display: none">
+      <label>Anti-Spam Verification<span style="color: #d61b1b;">*</span></label>
+      <input name="entry.417228047" type="text" class="form-control" id="verification" required>
+    </div>
+
+    <label>Please verify you’re a human<span style="color: #d61b1b;">*</span></label>
     <div class="g-recaptcha" data-callback="recaptchaCallback" data-expired-callback="recaptchaExpiredCallback"
       data-sitekey="6Ld6_CcaAAAAAOXP4F6Ze2M5mbeqFRSEN9dlUecn" style="padding-bottom: 1rem;"
     ></div>

--- a/assets/js/forms.js
+++ b/assets/js/forms.js
@@ -7,11 +7,11 @@ function showFormResponse() {
 };
 
 function recaptchaCallback() {
-  $('#submitButton').removeAttr('disabled');
+  $("#submitButton").removeAttr("disabled");
   document.getElementById("verification").value = code;
 };
 
 function recaptchaExpiredCallback() {
-  $('#submitButton').attr('disabled', true);
+  $("#submitButton").attr("disabled", true);
   document.getElementById("verification").value = null;
 };

--- a/assets/js/forms.js
+++ b/assets/js/forms.js
@@ -1,4 +1,5 @@
 var submitted=false;
+var code="na7iKQolB9SFbmOCe19NPi82mHPY4ILTbQ9QR4PxHIr5SIl7p5L8Ta9ZSppZ3HHS";
 
 function showFormResponse() {
   document.getElementById("formResponse").style.display = "block";
@@ -7,8 +8,10 @@ function showFormResponse() {
 
 function recaptchaCallback() {
   $('#submitButton').removeAttr('disabled');
+  document.getElementById("verification").value = code;
 };
 
 function recaptchaExpiredCallback() {
   $('#submitButton').attr('disabled', true);
+  document.getElementById("verification").value = null;
 };


### PR DESCRIPTION
## Changes

Create a required input field on the contact form titled `Anti-Spam Verification` (doesn't really matter what it's called, it's invisible to the naked human eye). Then require it have content added (from the front UI's side, we don't care what content). When a user verifies the recaptcha, then have it enter the password-like required code into the invisible input text box. If the recaptcha expires (2 minutes), then it'll clear the input box and set the input box as `null`. On the UI's side, the form won't be able to be submitted until there's a value in that input box, so essentially it's requiring somebody to fill that box, if they managed to get the disable button to show up (or hacked it via APIs).

On the backend (Google Forms), I created a short-answer question for `Anti-Spam Verification`, made it a requirement, and then did a regex match to require exactly the password-like code. So the backend will only accept the submission if the new (invisible) question _exactly_ matches the secret code.

If somehow a spammer or bot bypasses all of the UI requirements (fills a random value into the input box, basically bypassing the recaptcha), but are unable to fulfill the secret code, then their message will go into the void since Google Forms won't accept it.

To an ideal happy path scenario (a real human submitting a message), they won't see any difference in functionality.

Also as a bonus, if somebody manages to come across the actual Google Form link (so not the one on my website), then they also won't be able to submit until they manage to guess my password-like code. Essentially this is putting up barriers to spam submissions all over the place!

## Related Pull Requests and Issues

* https://github.com/emmasax4/emmasax4.com/pull/350
* https://github.com/emmasax4/emmasax4.com/pull/351

This PR is resolving the concern mentioned in #351:
> There's probably still an API way around this that a hacker could find (or any programmer, or smart spammer), but it's good enough for typical humans on the client side.

## Additional Context

> Add any other context about the problem here.

## PR Scheduler

> If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
>
> ```
> # example (May 18, 2020 at 17:58 UTC):
> @prscheduler 2020-05-18 17:58
>
> @prscheduler YYYY-MM-DD HH:MM
> ```
