### PR TITLE
Make it clear the reCAPTCHA is "required"

### DIFF
--- a/_blog_posts/adding-html-forms-to-static-sites.md
+++ b/_blog_posts/adding-html-forms-to-static-sites.md
@@ -44,7 +44,7 @@ Here's what my final HTML form looks like. Note that instead of rendering an ent
 
 ```html
 <script>
-  var submitted = false;
+  var formSubmitted = false;
 
   function showFormResponse() {
     document.getElementById("formResponse").style.display = "block";
@@ -55,11 +55,11 @@ Here's what my final HTML form looks like. Note that instead of rendering an ent
 <iframe name="hidden_iframe"
         id="hidden_iframe"
         style="display: none;"
-        onload="if (submitted) { showFormResponse() }">
+        onload="if (formSubmitted) { showFormResponse() }">
 </iframe>
 
 <div id="form">
-  <form method="post" target="hidden_iframe" onsubmit="submitted = true;"
+  <form method="post" target="hidden_iframe" onsubmit="formSubmitted = true;"
     action="https://docs.google.com/forms/d/e/ABDEFGHIJKLMNOPQRSTUVWXYZ/formResponse"
   >
     <div class="form-group">
@@ -219,3 +219,17 @@ All of my completed HTML can be found [here]({{ site.author_profiles.github }}/{
 * [www.google.com: ReCATPCHA creation](https://www.google.com/recaptcha/admin/create)
 * [developers.google.com: ReCAPTCHA docs](https://developers.google.com/recaptcha/docs/display)
 * [www.labnol.org: Useful Regular Expressions for Validating Input in Google Forms](https://www.labnol.org/internet/regular-expressions-forms/28380/)
+
+---
+
+EDIT: Since publishing this blog post, I've made one change to my form. Instead of making the invisible verification input required, I've instead added an additional check that will only show the "thank you" page if the reCAPTCHA was completed. Otherwise, it'll show a browser alert that the reCAPTCHA needs to be filled out first. Under the hood, the form actually tries to submit either way (whether the reCAPTCHA was completed or not), but Google Forms will just deny the request if the reCAPTCHA (and/or the invisible verification input) wasn't completed. To make it extra clear that the invisible input is required by the backend, just not enforced by the frontend, I wrote a little invisible message. This is what my new Javascript function looks like:
+
+```javascript
+function verifyRecaptcha() {
+  if (recaptchaCompleted) {
+    formSubmitted = true;
+  } else {
+    alert('Please fill out the reCAPTCHA to send a message.');
+  };
+};
+```

--- a/_layouts/contact.html
+++ b/_layouts/contact.html
@@ -14,14 +14,14 @@ layout: default
 <iframe name="hidden_iframe"
         id="hidden_iframe"
         style="display: none;"
-        onload="if (submitted) { showFormResponse() }">
+        onload="if (formSubmitted) { showFormResponse(); };">
 </iframe>
 
 <!-- The contact form for users to fill out -->
 <div id="form" class="page-body">
   {{ content | markdownify }}
 
-  <form method="post" target="hidden_iframe" onsubmit="submitted = true;"
+  <form method="post" target="hidden_iframe" onsubmit="verifyRecaptcha();"
     action="https://docs.google.com/forms/d/e/1FAIpQLScEq299mdRxHN_dZ3tTdgp6KTYtcgUHHVbDr0DSX2-zDDCxuQ/formResponse"
   >
     <div class="form-group">
@@ -39,9 +39,10 @@ layout: default
       <textarea name="entry.1379036791" class="form-control" id="message" placeholder="Lorem ipsum dolor sit amet, consectetur adipiscing elit." rows="3" required></textarea>
     </div>
 
-    <div class="form-group" style="display: none">
+    <div class="form-group" style="display: none;">
       <label>Anti-Spam Verification<span style="color: #d61b1b;">*</span></label>
-      <input name="entry.417228047" type="text" class="form-control" id="verification" required>
+      <p class="post-meta">NOTE: My HTML does not formally require this input to be filled in order to send a message. However, leaving this value blank will automatically prevent my form from <i>accepting</i> your message, even though my website will <i>tell</i> you the submission was successful.</p>
+      <input name="entry.417228047" type="text" class="form-control" id="verification">
     </div>
 
     <label>Please verify you’re a human<span style="color: #d61b1b;">*</span></label>
@@ -50,7 +51,7 @@ layout: default
     ></div>
 
     <button type="submit" id="submitButton" disabled class="btn btn-primary" style="width: 100%;">
-      Submit
+      Send Message
     </button>
   </form>
 </div>

--- a/assets/js/forms.js
+++ b/assets/js/forms.js
@@ -1,4 +1,5 @@
-var submitted = false;
+var formSubmitted = false;
+var recaptchaCompleted = false;
 var code = "na7iKQolB9SFbmOCe19NPi82mHPY4ILTbQ9QR4PxHIr5SIl7p5L8Ta9ZSppZ3HHS";
 
 function showFormResponse() {
@@ -8,10 +9,20 @@ function showFormResponse() {
 
 function recaptchaCallback(verificationResponse) {
   $("#submitButton").removeAttr("disabled");
+  recaptchaCompleted = true;
   document.getElementById("verification").value = verificationResponse + code + verificationResponse;
 };
 
 function recaptchaExpiredCallback() {
   $("#submitButton").attr("disabled", true);
+  recaptchaCompleted = false;
   document.getElementById("verification").value = null;
+};
+
+function verifyRecaptcha() {
+  if (recaptchaCompleted) {
+    formSubmitted = true;
+  } else {
+    alert('Please fill out the reCAPTCHA to send message.');
+  };
 };

--- a/assets/js/forms.js
+++ b/assets/js/forms.js
@@ -23,6 +23,6 @@ function verifyRecaptcha() {
   if (recaptchaCompleted) {
     formSubmitted = true;
   } else {
-    alert('Please fill out the reCAPTCHA to send message.');
+    alert('Please fill out the reCAPTCHA to send a message.');
   };
 };


### PR DESCRIPTION
## Changes

Under the hood, the form submission is all about the invisible input. Whether the submission message is accepted depends on what that value is set to. If it's empty or doesn't match the regex, it won't be accepted. However, to a user, it needs to be all about the reCATPCHA. We're assuming that nobody is looking at the actual `Anti-Spam Verification` input box.

So, if the reCAPTCHA isn't filled out, then let the user know by a browser alert that the reCAPTCHA is required. And then proceed to submit. Since most likely the `Anti-Spam Verification` won't be acceptable, it'll receive a 400 from Google Forms anyway. The user most likely won't see any of this, and they'll just fill out the reCAPTCHA and try again.

If the reCAPTCHA is filled out, then submit as normal, and most likely the form will be just fine.

If a sneaky user (or spammer) manages to fill out the `Anti-Spam Verification` w/out the reCAPTCHA, then there's two scenarios: 1) they'll be held up because the browser says you have to do the reCAPTCHA (if using a browser), or 2) the form will try to submit, but most likely the `Anti-Spam Verification` will be wrong, and Google Forms will deny the request (if using some sort of API).

If a sneaky user (or spammer) manages to complete the reCAPTCHA, but clears the `Anti-Spam Verification`, the message will attempt to send, but will be automatically denied by Google Forms. So, I wrote a nice message in the HTML that it is required by backend, but just not enforced by frontend.

This isn't a perfect solution, but it's better than what was there before.

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue #1
> * Issue #2
> * Pull Request #1
> * Pull Request #2

## Additional Context

> Add any other context about the problem here.

## PR Scheduler

> If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
>
> ```
> # example (May 18, 2020 at 17:58 UTC):
> @prscheduler 2020-05-18 17:58
>
> @prscheduler YYYY-MM-DD HH:MM
> ```
