### PR TITLE
Pull out inline Javascript to their own files

### DIFF
--- a/_blog_posts/301-redirects-with-static-sites.md
+++ b/_blog_posts/301-redirects-with-static-sites.md
@@ -25,7 +25,7 @@ What I found was [this solution](https://opensource.com/article/19/7/permanently
 I created [this repository]({{ site.author_profiles.github }}/emmasax4-redirects) to put my new redirects in. I started by taking a modified version of the HTML code in that blog post, which looked something like this:
 
 ```html
-<!DOCTYPE html>
+{% raw %}<!DOCTYPE html>
 <html lang="en-US">
   <meta charset="utf-8">
   <title>Redirecting&hellip;</title>
@@ -37,7 +37,7 @@ I created [this repository]({{ site.author_profiles.github }}/emmasax4-redirects
   <meta name="robots" content="noindex">
   <h1>Redirecting&hellip;</h1>
   <a href="https://destination-domain.com">Click here if you are not redirected.</a>
-</html>
+</html>{% endraw %}
 ```
 
 This worked. I duplicated each `index.html` file on the original site into this new project, replicating the files found [here]({{ site.author_profiles.github }}/{{ site.github_repo }}/tree/4c4aaed77f44ccf743ce47ddef9c91c9a89528a4). But I realized this wasn't sustainable. I didn't want to be copy-pasting HTML from each file to another all over the place. I wanted _one_ HTML file that would properly redirect any incoming path to the new domain, and forwarding the same path, without me having to make constant updates to the new redirect repository.
@@ -63,7 +63,7 @@ setTimeout(function(){ window.location.href = "https://destination-domain.com" +
 Now, with this Javascript, the key was to use it in two places: the button, and the delay. This was the ending solution:
 
 ```html
-<script type="text/javascript">
+{% raw %}<script type="text/javascript">
   var pathname = window.location.pathname;
 
   // Perform an automatic timed redirect
@@ -77,7 +77,7 @@ Now, with this Javascript, the key was to use it in two places: the button, and 
 
 <button class="btn btn-lg btn-outline-secondary" onclick="redirect_now(); return false;">
   Click here if you are not redirected.
-</button>
+</button>{% endraw %}
 ```
 
 Bam! Now, no matter what path a user passes in after the `/`, they'll be forwarded to the exact same URL with just a different domain 🥳. The last part of this project was to remove all of the extra `index.html` files. All we really need are the root `index.html` to catch when someone navigates to `https://emmasax4.info` directly, and a page to catch when somebody navigates to.... anything else (`https://emmasax4.info/anything/else/goes/here`). In that case, we can just make a `404.html` file. If the user navigates to anything else besides the plain root, then GitHub Pages will show the `404.html` page. And if the `404.html` functionality redirects to the new domain, _while passing the end of the path (`/anything/else/goes/here`)_, then the `404.html` page acts as a catch-all. So, I created a symlinked file off of the `index.html` page:

--- a/_blog_posts/adding-html-forms-to-static-sites.md
+++ b/_blog_posts/adding-html-forms-to-static-sites.md
@@ -43,7 +43,7 @@ For the first four steps (creating a Google Form, creating a custom HTML form th
 Here's what my final HTML form looks like. Note that instead of rendering an entirely new "thank you" page, I simply replace the form `div` with a "thank you" `div`. This is my personal preference, so that there's not an entirely new page just to say thanks for submitting a message.
 
 ```html
-<script>
+{% raw %}<script>
   var formSubmitted = false;
 
   function showFormResponse() {
@@ -87,7 +87,7 @@ Here's what my final HTML form looks like. Note that instead of rendering an ent
   <div class="text-center">
     <a href="/" class="btn">Back to Homepage</a>
   </div>
-</div>
+</div>{% endraw %}
 ```
 
 Here is a picture of what the form now looks like:

--- a/_blog_posts/bootstrap-css-and-icons-in-this-site.md
+++ b/_blog_posts/bootstrap-css-and-icons-in-this-site.md
@@ -76,8 +76,8 @@ The `link-icon` class is something that I've created with common link-icon setti
 Lastly, as long as these two lines are at the bottom of the file, the icons appear magically!
 
 ```html
-<script src="https://unpkg.com/feather-icons"></script>
-<script>feather.replace()</script>
+{% raw %}<script src="https://unpkg.com/feather-icons"></script>
+<script>feather.replace()</script>{% endraw %}
 ```
 
 See them in action [here]({{ site.author_profiles.github }}/{{ site.github_repo }}/blob/129867d8135a930f4d364fe026db123d655b5ca8/_includes/site/scripts.html#L3-L4).

--- a/_blog_posts/opening-links-in-new-tabs-via-javascript.md
+++ b/_blog_posts/opening-links-in-new-tabs-via-javascript.md
@@ -74,7 +74,7 @@ So, neither of these options are perfect, and I don't like either of them. I wan
 After several pull requests of me changing my mind about how to write links, and doing massive search-replaces in my codebase, I found a different kind of solution... a solution that involves Javascript. Static sites (like mine) can use Javascript to do view-based logic and methods right in front of the user. It's unwise to incorporate _a lot_ of Javascript on a single page because it'll slow down loading and operation times, but it's how I did simply functionality, like showing the comments on the bottom of each page or loading the Feather icons. And so of course, somebody has written [this blog post](https://html.com/attributes/a-target/) which nicely provides a Javascript solution for opening every external URL in a new tab. This script is what is suggested to be placed at the bottom of our HTML files:
 
 ```html
-<script type="text/javascript">
+{% raw %}<script type="text/javascript">
   function externalLinks() {
     for(var c = document.getElementsByTagName('a'), a = 0; a < c.length; a++) {
       var b = c[a];
@@ -82,7 +82,7 @@ After several pull requests of me changing my mind about how to write links, and
     }
   };
   externalLinks();
-</script>
+</script>{% endraw %}
 ```
 
 It's very simple, but yet, it covers almost exactly what I need. On every page that's loaded, it will go through my converted and compiled HTML, find each attribute that contains a link, and will guarantee that each EXTERNAL link will open to a new tab, and that each INTERNAL link opens to the current tab. Voilà!
@@ -116,7 +116,7 @@ Similarly, if a link is explicitly written with `target="_blank"`, no matter whe
 Here's what my new script looks like with [html.com](https://html.com/)'s suggestion and my edits:
 
 ```html
-<!--
+{% raw %}<!--
 To open an EXTERNAL link in the CURRENT tab, write your link like this:
   <a href="https://github.com" target="_self">GitHub</a>
 
@@ -138,7 +138,7 @@ To open an INTERNAL link in a NEW tab, write your link like this:
     };
   };
   openExternalLinksInNewTabs();
-</script>
+</script>{% endraw %}
 ```
 
 Now this _**really**_ does everything I need. 🙌🏼

--- a/_blog_posts/time-zones-utc-and-javascript-oh-my.md
+++ b/_blog_posts/time-zones-utc-and-javascript-oh-my.md
@@ -104,7 +104,7 @@ return monthNames[monthIndex] + ' ' + day + ', ' + year; // January 17, 2020
 All together, this now looks like this:
 
 ```html
-<script type="text/javascript">
+{% raw %}<script type="text/javascript">
   function showDatesInLocalTime() {
     var dates = document.getElementsByClassName('date-meta');
     var monthNames = ['January', 'February', 'March', 'April', 'May', 'June',
@@ -124,7 +124,7 @@ All together, this now looks like this:
     };
   };
   showDatesInLocalTime();
-</script>
+</script>{% endraw %}
 ```
 
 I'm hiding a lot of the effort this took me... don't get me wrong, it took me what felt like _hours_ to develop this method, and I'm still finding bugs in it 🦟.

--- a/_layouts/contact.html
+++ b/_layouts/contact.html
@@ -8,7 +8,7 @@ layout: default
 </div>
 
 <!-- Frame and Javascript information -->
-<script src="/assets/js/forms.js" type="text/javascript"></script>
+<script src="/assets/js/forms.js"></script>
 <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 
 <iframe name="hidden_iframe"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -37,18 +37,18 @@
 
   <!-- Footer -->
   <footer>
-    &copy; <script>document.write(new Date().getFullYear());</script>
+    &copy; <script src="/assets/js/get_full_year.js"></script>
     Emma Sax. All rights reserved.
     <br>
     View on <a href="{{ site.author_profiles.github }}/{{ site.github_repo }}">GitHub</a>.
   </footer>
 
   <!-- Javascript scripts -->
-  <script src="/assets/js/show_dates.js" type="text/javascript"></script>
-  <script src="/assets/js/external_links.js" type="text/javascript"></script>
+  <script src="/assets/js/show_dates.js"></script>
+  <script src="/assets/js/external_links.js"></script>
   <script src="/assets/js/jquery.min.js"></script>
   <script src="/assets/js/lightbox.min.js"></script>
   <script src="/assets/js/bootstrap.min.js"></script>
   <script src="/assets/js/feather.min.js"></script>
-  <script>feather.replace()</script>
+  <script src="/assets/js/activate_feather.js"></script>
 </html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -48,7 +48,7 @@ layout: default
       {{ content }}
 
       {% if page.comments != false and jekyll.environment == "production" %}
-        <script src="/assets/js/show_comments.js" type="text/javascript"></script>
+        <script src="/assets/js/show_comments.js"></script>
 
         <div class="text-center" style="margin-bottom: 1rem;">
           <button id="show-comments-button" class="btn btn-lg btn-outline-secondary" onclick="loadComments('{{ site.disqus.shortname }}'); return false;">

--- a/assets/js/activate_feather.js
+++ b/assets/js/activate_feather.js
@@ -1,0 +1,1 @@
+feather.replace()

--- a/assets/js/get_full_year.js
+++ b/assets/js/get_full_year.js
@@ -1,0 +1,1 @@
+document.write(new Date().getFullYear());


### PR DESCRIPTION
## Changes

Pull out all existing inline Javascript to their own external JS files. Do this to prepare for adding a meta HTML tag with a content security policy that disallows inline Javascript.

Also, I added some `{% raw %}{% endraw %}` to the blog posts where I have code blocks that write `<script>`, so that will hopefully keep those pieces showing up on the HTML even when the CSP is added.

## Related Pull Requests and Issues

* https://github.com/emmasax4/emmasax4.com/pull/365
* https://github.com/emmasax4/emmasax4.com/pull/366

## Additional Context

N/A

## PR Scheduler

> If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
>
> ```
> # example (May 18, 2020 at 17:58 UTC):
> @prscheduler 2020-05-18 17:58
>
> @prscheduler YYYY-MM-DD HH:MM
> ```
