### PR TITLE
Fix typo as caused by {% raw %}

### DIFF
--- a/_blog_posts/opening-links-in-new-tabs-via-javascript.md
+++ b/_blog_posts/opening-links-in-new-tabs-via-javascript.md
@@ -121,7 +121,7 @@ To open an EXTERNAL link in the CURRENT tab, write your link like this:
   <a href="https://github.com" target="_self">GitHub</a>
 
 To open an INTERNAL link in a NEW tab, write your link like this:
-  <a href="https://{{ site.domain }}" target="_blank">My website</a>
+  <a href="https://emmasax4.com" target="_blank">My website</a>
 -->
 <script type="text/javascript">
   function openExternalLinksInNewTabs() {


### PR DESCRIPTION
## Changes

Now that we use `{% raw %}` on the code block in the Opening Links in New Tabs via Javascript blog post, we need to hard-code the domain of the site into the code block, otherwise it won't evaluate.

## Related Pull Requests and Issues

* https://github.com/emmasax4/emmasax4.com/pull/364

## Additional Context

> Add any other context about the problem here.

## PR Scheduler

> If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
>
> ```
> # example (May 18, 2020 at 17:58 UTC):
> @prscheduler 2020-05-18 17:58
>
> @prscheduler YYYY-MM-DD HH:MM
> ```
