### PR TITLE
Fix textarea bug

### DIFF
--- a/_layouts/contact.html
+++ b/_layouts/contact.html
@@ -32,8 +32,8 @@ layout: default
     <div class="form-group">
       <label>Message<span class="form-required">*</span></label>
       <textarea name="entry.1379036791" class="form-control" id="message" rows="3"
-        placeholder="Lorem ipsum dolor sit amet, consectetur adipiscing elit." required>
-      </textarea>
+        placeholder="Lorem ipsum dolor sit amet, consectetur adipiscing elit." required
+      ></textarea>
     </div>
 
     <div class="form-group invisible">


### PR DESCRIPTION
## Changes

Fix bug where the textarea automatically starts with spaces. Essentially I placed the `</textarea>` line on a different line than the close of the `<textarea>`, meaning the spaces on HTML formatting are placed there. So I just moved the last `>` onto the same line.

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue #1
> * Issue #2
> * Pull Request #1
> * Pull Request #2

## Additional Context

> Add any other context about the problem here.

## PR Scheduler

> If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
>
> ```
> # example (May 18, 2020 at 17:58 UTC):
> @prscheduler 2020-05-18 17:58
>
> @prscheduler YYYY-MM-DD HH:MM
> ```
