### PR TITLE
Specify for jekyll-seo-tag that we want to prioritize the site title

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,13 +6,6 @@ GIT
       jekyll (>= 3.7, < 5.0)
 
 GIT
-  remote: https://github.com/emmasax4/jekyll-seo-tag
-  revision: a63c6609223db15c9cfc04be27fa13e10b6b0778
-  specs:
-    jekyll-seo-tag (2.7.1)
-      jekyll (>= 3.8, < 5.0)
-
-GIT
   remote: https://github.com/emmasax4/jekyll-sitemap
   revision: 20b23fbae6f5a614f94e14d7f32616ec6ee4cb63
   specs:
@@ -25,6 +18,12 @@ GIT
   specs:
     jekyll-commonmark (1.3.1)
       commonmarker (~> 0.14)
+
+PATH
+  remote: /Users/emmasax/projects/jekyll-seo-tag
+  specs:
+    jekyll-seo-tag (2.7.1)
+      jekyll (>= 3.8, < 5.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,13 @@ GIT
       jekyll (>= 3.7, < 5.0)
 
 GIT
+  remote: https://github.com/emmasax4/jekyll-seo-tag
+  revision: 2fc4463ff99317c7b92a8a6ee4d73606d9fc9728
+  specs:
+    jekyll-seo-tag (2.7.1)
+      jekyll (>= 3.8, < 5.0)
+
+GIT
   remote: https://github.com/emmasax4/jekyll-sitemap
   revision: 20b23fbae6f5a614f94e14d7f32616ec6ee4cb63
   specs:
@@ -18,12 +25,6 @@ GIT
   specs:
     jekyll-commonmark (1.3.1)
       commonmarker (~> 0.14)
-
-PATH
-  remote: /Users/emmasax/projects/jekyll-seo-tag
-  specs:
-    jekyll-seo-tag (2.7.1)
-      jekyll (>= 3.8, < 5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -39,7 +40,7 @@ GEM
     ast (2.4.2)
     chef-utils (16.10.8)
     colorator (1.1.0)
-    commonmarker (0.21.1)
+    commonmarker (0.21.2)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.1.8)
     em-websocket (0.5.2)

--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,11 @@ github_repo: emmasax4.com
 timezone: UTC
 jekyll-mentions: https://github.com
 
+# This is a custom property for my fork of jekyll-seo-tag. I set it to prioritize the title
+# of my site over the title of each page. If this is not set, the default is to prioritize
+# the title of the page first.
+seo_title_prioritization: site
+
 markdown: CommonMark
 commonmark:
   options:


### PR DESCRIPTION
## Changes

Set my custom fork of jekyll-seo-tag to prioritize the title of my site over the title of each page. If this is not set, the default is to prioritize the title of the page first. To do this, just add this to the `_config.yml`:
```yml
seo_title_prioritization: site
```

There should be no functionality changes to this website.

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue #1
> * Issue #2
> * Pull Request #1
> * Pull Request #2

## Additional Context

> Add any other context about the problem here.

## PR Scheduler

> If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
>
> ```
> # example (May 18, 2020 at 17:58 UTC):
> @prscheduler 2020-05-18 17:58
>
> @prscheduler YYYY-MM-DD HH:MM
> ```
